### PR TITLE
Add triggers definition to API Gateway deployment resource

### DIFF
--- a/infrastructure/terraform.tf
+++ b/infrastructure/terraform.tf
@@ -175,6 +175,14 @@ resource "aws_api_gateway_deployment" "cinematica_deployment" {
     provider = aws.us_east
     rest_api_id = aws_api_gateway_rest_api.cinematica_api_gateway.id
 
+    triggers = {
+        redeployment = sha1(jsonencode([
+            aws_api_gateway_resource.cinematica_api_gateway_resource.id,
+            aws_api_gateway_method.cinematica_api_gateway_proxy_method.id,
+            aws_api_gateway_integration.cinematica_api_gateway_integration.id
+        ]))
+    }
+
     lifecycle {
         create_before_destroy = true
     }


### PR DESCRIPTION
This is required to ensure the deployment resource is created in the right order. Previously, Terraform tried to create a deployment before the other resources were created, and so it errored. The deployment resource does not have any natural implicit references to make to these resources, so instead we set Triggers to put these references (dependencies) in.